### PR TITLE
feat: add support for prependBaseUrlToResourcesPath configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**0.1.7**
+- Added support of `dbadmin.prepend-base-url-to-resources-path` configuration option
+
 **0.1.6**
 - Support for JPA validation (#12)
 - Support for UUID type (#13)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ dbadmin.modelsPackage=your.models.package,your.second.models.package
 ## Set to true if you need to run the tests, as it will customize
 ## the database configuration for the internal DataSource
 # dbadmin.testMode=false
+#
+## Set to true if you need to set the static resources path
+## to the same than application path, can be useful if the application
+## is hosted behind a reverse proxy with a prefix path
+# dbadmin.prepend-base-url-to-resources-path=true
 ```
 
 Now annotate your `@SpringBootApplication` class containing the `main` method with the following:

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>tech.ailef</groupId>
 	<artifactId>spring-boot-db-admin</artifactId>
-	<version>0.1.6</version>
+	<version>0.1.7</version>
 	<name>spring-boot-db-admin</name>
 	<description>Spring Boot Database Admin is an auto-generated CRUD admin panel for Spring Boot apps</description>
 	<properties>

--- a/src/main/java/tech/ailef/dbadmin/external/DbAdminAutoConfiguration.java
+++ b/src/main/java/tech/ailef/dbadmin/external/DbAdminAutoConfiguration.java
@@ -37,7 +37,7 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
-
+import tech.ailef.dbadmin.external.controller.MvcConfig;
 import tech.ailef.dbadmin.internal.InternalDbAdminConfiguration;
 
 /**
@@ -56,7 +56,10 @@ import tech.ailef.dbadmin.internal.InternalDbAdminConfiguration;
 	basePackages = { "tech.ailef.dbadmin.internal.repository" }
 )
 @EnableTransactionManagement
-@Import(InternalDbAdminConfiguration.class)
+@Import({
+	InternalDbAdminConfiguration.class,
+	MvcConfig.class
+})
 public class DbAdminAutoConfiguration {
 	@Autowired
 	private DbAdminProperties props;

--- a/src/main/java/tech/ailef/dbadmin/external/DbAdminProperties.java
+++ b/src/main/java/tech/ailef/dbadmin/external/DbAdminProperties.java
@@ -41,6 +41,11 @@ public class DbAdminProperties {
 	private String baseUrl;
 
 	/**
+	 * Set to true to prepend baseUrl to static resources path (css, js)
+	 */
+	private boolean prependBaseUrlToResourcesPath;
+
+	/**
 	 * The path of the package that contains your JPA `@Entity` classes to be scanned.
 	 */
 	private String modelsPackage;
@@ -65,7 +70,15 @@ public class DbAdminProperties {
 	public void setBaseUrl(String baseUrl) {
 		this.baseUrl = baseUrl;
 	}
-	
+
+	public void setPrependBaseUrlToResourcesPath(boolean prependBaseUrlToResourcesPath) {
+		this.prependBaseUrlToResourcesPath = prependBaseUrlToResourcesPath;
+	}
+
+	public boolean isPrependBaseUrlToResourcesPath() {
+		return prependBaseUrlToResourcesPath;
+	}
+
 	public String getModelsPackage() {
 		return modelsPackage;
 	}
@@ -81,11 +94,16 @@ public class DbAdminProperties {
 	public void setTestMode(boolean testMode) {
 		this.testMode = testMode;
 	}
-	
+
+	public String getResourcesPath() {
+		return prependBaseUrlToResourcesPath ? "/"+baseUrl : "";
+	}
+
 	public Map<String, String> toMap() {
 		Map<String, String> conf = new HashMap<>();
 		conf.put("enabled", enabled + "");
 		conf.put("baseUrl", baseUrl);
+		conf.put("resourcesPath", getResourcesPath());
 		conf.put("modelsPackage", modelsPackage);
 		conf.put("testMode", testMode + "");
 		return conf;

--- a/src/main/java/tech/ailef/dbadmin/external/controller/GlobalController.java
+++ b/src/main/java/tech/ailef/dbadmin/external/controller/GlobalController.java
@@ -59,6 +59,7 @@ public class GlobalController {
 		model.addAttribute("message", e.getMessage());
 		model.addAttribute("dbadmin_userConf", userConf);
 		model.addAttribute("dbadmin_baseUrl", getBaseUrl());
+		model.addAttribute("dbadmin_resourcesPath", getResourcesPath());
 		model.addAttribute("dbadmin_version", dbAdmin.getVersion());
 		response.setStatus(404);
 		return "other/error";
@@ -107,6 +108,16 @@ public class GlobalController {
 	@ModelAttribute("dbadmin_userConf")
 	public UserConfiguration getUserConf() {
 		return userConf;
+	}
+
+
+	/**
+	 * The resources path, either empty, or equals to baseUrl depending of
+	 * @return
+	 */
+	@ModelAttribute("dbadmin_resourcesPath")
+	public String getResourcesPath() {
+		return props.getResourcesPath();
 	}
 }
 

--- a/src/main/java/tech/ailef/dbadmin/external/controller/MvcConfig.java
+++ b/src/main/java/tech/ailef/dbadmin/external/controller/MvcConfig.java
@@ -1,0 +1,23 @@
+package tech.ailef.dbadmin.external.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import tech.ailef.dbadmin.external.DbAdminProperties;
+
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@Configuration
+public class MvcConfig implements WebMvcConfigurer {
+
+    @Autowired
+    private DbAdminProperties props;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry
+            .addResourceHandler(props.getResourcesPath() + "/**")
+            .addResourceLocations("classpath:/static/");
+    }
+}

--- a/src/main/resources/templates/fragments/resources.html
+++ b/src/main/resources/templates/fragments/resources.html
@@ -3,15 +3,15 @@
 	<head th:fragment="head">
 		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.2/font/bootstrap-icons.css" integrity="sha384-b6lVK+yci+bfDmaY1u0zE8YYJt0TZxLEAFyYSLHId4xoVvsrQu3INevFKo+Xir8e" crossorigin="anonymous">
-		<link rel="stylesheet" href="/css/dbadmin.css">
-		<link rel="stylesheet" href="/css/style.css">
+		<link rel="stylesheet" th:href="|${dbadmin_resourcesPath}/css/dbadmin.css|">
+		<link rel="stylesheet" th:href="|${dbadmin_resourcesPath}/css/style.css|">
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.3/js/bootstrap.min.js" integrity="sha512-1/RvZTcCDEUjY/CypiMz+iqqtaoQfAITmNSJY17Myp4Ms5mdxPS5UV7iOfdZoxcGhzFbOm6sntTKJppjvuhg4g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-		<script type="text/javascript" src="/js/table.js"></script>
-		<script type="text/javascript" src="/js/autocomplete.js"></script>
-		<script type="text/javascript" src="/js/autocomplete-multi.js"></script>
-		<script type="text/javascript" src="/js/filters.js"></script>
-		<script type="text/javascript" src="/js/logs.js"></script>
-		<script type="text/javascript" src="/js/create.js"></script>
+		<script type="text/javascript" th:src="|${dbadmin_resourcesPath}/js/table.js|"></script>
+		<script type="text/javascript" th:src="|${dbadmin_resourcesPath}/js/autocomplete.js|"></script>
+		<script type="text/javascript" th:src="|${dbadmin_resourcesPath}/js/autocomplete-multi.js|"></script>
+		<script type="text/javascript" th:src="|${dbadmin_resourcesPath}/js/filters.js|"></script>
+		<script type="text/javascript" th:src="|${dbadmin_resourcesPath}/js/logs.js|"></script>
+		<script type="text/javascript" th:src="|${dbadmin_resourcesPath}/js/create.js|"></script>
 		<title th:text="${title != null ? title + ' | Spring Boot DB Admin Panel' : 'Spring Boot DB Admin Panel'}"></title>
 		<script th:inline="javascript">
 		    let baseUrl = [[ ${dbadmin_baseUrl} ]];


### PR DESCRIPTION
In this commit, a new configuration option `dbadmin.prepend-base-url-to-resources-path` is added. This option is used when there is a need to set the static resources path to the same as the application path. This might be useful when the application is hosted behind a reverse proxy with a prefix path.